### PR TITLE
Remove from tsconfig anything we don't need

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "composite": true, // enforces constraints which make it possible for build tools (including ts) to quickly determine if a project has been built yet
-    "outDir": "dist", // .js (as well as .d.ts, .js.map, etc.) files will be emitted into this directory.
+    "outDir": "build", // .js (as well as .d.ts, .js.map, etc.) files will be emitted into this directory.
+    "rootDir": "src", // specify the root folder within your source files.
     "sourceMap": true, // enables the generation of sourcemap files.
     "strict": true, // enables a wide range of type checking behavior that results in stronger guarantees of program correctness.
     "esModuleInterop": true, // emit additional JavaScript to ease support for importing CommonJS modules.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,32 +1,15 @@
 {
   "compilerOptions": {
-    "target": "ES6",
-    "module": "CommonJS",
-    "moduleResolution": "Node",
-    "lib": [
-      "ESNext",
-      "ESNext.AsyncIterable",
-      // "DOM"
-    ],
-    // "noImplicitReturns": true,
-    "stripInternal": true,
-    "noUnusedLocals": true,
-    "esModuleInterop": true,
-    "allowJs": true,
-    "sourceMap": true,
-    "strict": true,
-    "noEmit": false,
-    "experimentalDecorators": true,
-    "baseUrl": ".",
-    "rootDir": "./src",
-    "outDir": "./build",
-    "types": [
-      "@types/node"
-    ]
+    "composite": true, // enforces constraints which make it possible for build tools (including ts) to quickly determine if a project has been built yet
+    "outDir": "dist", // .js (as well as .d.ts, .js.map, etc.) files will be emitted into this directory.
+    "sourceMap": true, // enables the generation of sourcemap files.
+    "strict": true, // enables a wide range of type checking behavior that results in stronger guarantees of program correctness.
+    "esModuleInterop": true, // emit additional JavaScript to ease support for importing CommonJS modules.
+    "lib": ["esnext", "dom"] // specify a set of bundled library declaration files that describe the target runtime environment.
   },
   "exclude": [
     "node_modules",
-    "build",
-    "test",
+    "dist",
+    "test"
   ]
 }


### PR DESCRIPTION
We need "dom" in "lib" so we can override Websocket, which is needed for
gather-game-client to work in node.

Everytihng else should be self explanatory and is commented wth the
explanation from the documentation.